### PR TITLE
Fix duplicate repository widgets display

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ back_to_top: true # set to false to disable the back to top button
 repo_theme_light: default # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
 repo_theme_dark: dark # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
 repo_trophies:
-  enabled: true
+  enabled: false
   theme_light: flat # https://github.com/ryo-ma/github-profile-trophy
   theme_dark: gitdimmed # https://github.com/ryo-ma/github-profile-trophy
 


### PR DESCRIPTION
- Disable repo_trophies to prevent duplicate display of repository controls
- The repositories page was showing both GitHub stats cards and trophies
- Now only displays the GitHub user stats card for cleaner presentation

This fixes the issue where repository controls appeared twice on the page.